### PR TITLE
Usage of proper class inheritance check for limiting query

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -566,7 +566,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$query = $this->replacePrefix((string) $this->sql);
 
-		if (!($this->sql instanceof JDatabaseQuery) && ($this->limit > 0 || $this->offset > 0))
+		if (!($this->sql instanceof JDatabaseQueryLimitable) && ($this->limit > 0 || $this->offset > 0))
 		{
 			$query .= ' LIMIT ' . $this->offset . ', ' . $this->limit;
 		}


### PR DESCRIPTION
Pull Request for Issue #10108

#### Summary of Changes

#### Testing Instructions

Instead of checking for instance of JDatabaseQuery should check query implements JDatabaseQueryLimitable interface